### PR TITLE
feat: yearQuarter parsing and struct

### DIFF
--- a/src/Chrononuensis.Core.Testing/Formats/LexerTests.cs
+++ b/src/Chrononuensis.Core.Testing/Formats/LexerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Chrononuensis.Formats;
 using Chrononuensis.Formats.Tokens;
 using Chrononuensis.Formats.Tokens.Month;
+using Chrononuensis.Formats.Tokens.Quarter;
 using Chrononuensis.Formats.Tokens.Year;
 using NUnit.Framework;
 
@@ -80,4 +81,14 @@ public class LexerTests
         Assert.That(format.Last(), Is.TypeOf<PaddedDigitMonthToken>());
     }
 
+    [TestCase("yyyy'-Q'q")]
+    public void Tokenize_WithFourDistinctTokens_ReturnsTokens(string input)
+    {
+        var format = new Lexer().Tokenize(input);
+        Assert.That(format.Count(), Is.EqualTo(4));
+        Assert.That(format.First(), Is.TypeOf<DigitOn4YearToken>());
+        Assert.That(format.ElementAt(1), Is.TypeOf<LiteralToken>());
+        Assert.That(format.ElementAt(2), Is.TypeOf<LiteralToken>());
+        Assert.That(format.Last(), Is.TypeOf<DigitQuarterToken>());
+    }
 }

--- a/src/Chrononuensis.Core.Testing/Parsers/YearMonthParserTests.cs
+++ b/src/Chrononuensis.Core.Testing/Parsers/YearMonthParserTests.cs
@@ -21,8 +21,11 @@ public class YearMonthParserTests
     {
         var parser = new YearMonthParser();
         var result = parser.Parse(input, format, null);
-        Assert.That(result.Year, Is.EqualTo(2025));
-        Assert.That(result.Month, Is.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Year, Is.EqualTo(2025));
+            Assert.That(result.Month, Is.EqualTo(1));
+        });
     }
 
     [Test]

--- a/src/Chrononuensis.Core.Testing/Parsers/YearQuarterParserTests.cs
+++ b/src/Chrononuensis.Core.Testing/Parsers/YearQuarterParserTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chrononuensis.Parsers;
+using NUnit.Framework;
+
+namespace Chrononuensis.Testing.Parsers;
+public class YearQuarterParserTests
+{
+    [TestCase("25-Q1", "yy-Qq")]
+    [TestCase("25-1", "yy-q")]
+    [TestCase("Q1.2025", "Qq.yyyy")]
+    public void Parse_InputFormat_CorrectValue(string input, string format)
+    {
+        var parser = new YearQuarterParser();
+        var result = parser.Parse(input, format, null);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Year, Is.EqualTo(2025));
+            Assert.That(result.Quarter, Is.EqualTo(1));
+        });
+    }
+}

--- a/src/Chrononuensis.Core.Testing/YearMonthTests.cs
+++ b/src/Chrononuensis.Core.Testing/YearMonthTests.cs
@@ -12,15 +12,54 @@ public class YearMonthTests
     public void Parse_InputDefaultFormat_Equal()
         => Assert.That(YearMonth.Parse("2021-01", "yyyy-MM"), Is.EqualTo(new YearMonth(2021,1)));
 
-    [Test]
-    public void Equals_Distinct_False()
-        => Assert.That(new YearMonth(2021, 1) == new YearMonth(2021, 2), Is.False);
+    private static IEnumerable<YearMonth> GetData()
+    {
+        yield return new(2022, 1);
+        yield return new(2021, 2);
+        yield return new(2022, 2);
+    }
+
+    [TestCaseSource(nameof(GetData))]
+    public void LessThan_YearMonth_Compared(YearMonth right)
+        => Assert.That(new YearMonth(2021, 1) < right, Is.True);
+
+    [TestCaseSource(nameof(GetData))]
+    public void LessThanOrEqual_YearMonth_Compared(YearMonth right)
+        => Assert.That(new YearMonth(2021, 1) <= right, Is.True);
 
     [Test]
-    public void Equals_Same_True()
+    public void LessThanOrEqual_YearMonth_Compared()
+        => Assert.That(new YearMonth(2021, 1) <= new YearMonth(2021, 1), Is.True);
+
+    [TestCaseSource(nameof(GetData))]
+    public void GreaterThan_YearMonth_Compared(YearMonth right)
+        => Assert.That(new YearMonth(2021, 1) > right, Is.False);
+
+    [TestCaseSource(nameof(GetData))]
+    public void GreaterThanOrEqual_YearMonth_Compared(YearMonth right)
+        => Assert.That(new YearMonth(2021, 1) >= right, Is.False);
+
+    [Test]
+    public void GreaterThanOrEqual_YearMonth_Compared()
+        => Assert.That(new YearMonth(2021, 1) >= new YearMonth(2021, 1), Is.True);
+
+    [TestCaseSource(nameof(GetData))]
+    public void NotEqual_YearMonth_Compared(YearMonth right)
+        => Assert.That(new YearMonth(2021, 1) != right, Is.True);
+
+    [Test]
+    public void Equal_YearMonth_Compared()
         => Assert.That(new YearMonth(2021, 1) == new YearMonth(2021, 1), Is.True);
 
     [Test]
-    public void Compare_Distinct_Compared()
-        => Assert.That(new YearMonth(2021, 1) < new YearMonth(2021, 2), Is.True);
+    public void CompareTo_Null_Compared()
+        => Assert.That(new YearMonth(2021, 1).CompareTo(null), Is.EqualTo(1));
+
+    [Test]
+    public void CompareTo_ItSelf_Compared()
+        => Assert.That(new YearMonth(2021, 1).CompareTo(new YearMonth(2021, 1)), Is.EqualTo(0));
+
+    [Test]
+    public void CompareTo_SomethingElse_Compared()
+        => Assert.That(new YearMonth(2021, 1).CompareTo(new YearMonth(2022, 3)), Is.EqualTo(-1));
 }

--- a/src/Chrononuensis.Core.Testing/YearQuaterTests.cs
+++ b/src/Chrononuensis.Core.Testing/YearQuaterTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Chrononuensis.Testing;
+public class YearQuarterTests
+{
+    [Test]
+    public void Parse_InputDefaultFormat_Equal()
+        => Assert.That(YearQuarter.Parse("2021-Q1", "yyyy-Qq"), Is.EqualTo(new YearQuarter(2021,1)));
+
+    private static IEnumerable<YearQuarter> GetData()
+    {
+        yield return new(2022, 1);
+        yield return new(2021, 2);
+        yield return new(2022, 2);
+    }
+        
+    [TestCaseSource(nameof(GetData))]
+    public void LessThan_YearQuarter_Compared(YearQuarter right)
+        => Assert.That(new YearQuarter(2021, 1) < right, Is.True);
+
+    [TestCaseSource(nameof(GetData))]
+    public void LessThanOrEqual_YearQuarter_Compared(YearQuarter right)
+        => Assert.That(new YearQuarter(2021, 1) <= right, Is.True);
+
+    [Test]
+    public void LessThanOrEqual_YearQuarter_Compared()
+        => Assert.That(new YearQuarter(2021, 1) <= new YearQuarter(2021, 1), Is.True);
+
+    [TestCaseSource(nameof(GetData))]
+    public void GreaterThan_YearQuarter_Compared(YearQuarter right)
+        => Assert.That(new YearQuarter(2021, 1) > right, Is.False);
+
+    [TestCaseSource(nameof(GetData))]
+    public void GreaterThanOrEqual_YearQuarter_Compared(YearQuarter right)
+        => Assert.That(new YearQuarter(2021, 1) >= right, Is.False);
+
+    [Test]
+    public void GreaterThanOrEqual_YearQuarter_Compared()
+        => Assert.That(new YearQuarter(2021, 1) >= new YearQuarter(2021, 1), Is.True);
+
+    [TestCaseSource(nameof(GetData))]
+    public void NotEqual_YearQuarter_Compared(YearQuarter right)
+        => Assert.That(new YearQuarter(2021, 1) != right, Is.True);
+
+    [Test]
+    public void Equal_YearQuarter_Compared()
+        => Assert.That(new YearQuarter(2021, 1) == new YearQuarter(2021, 1), Is.True);
+    [Test]
+    public void CompareTo_Null_Compared()
+        => Assert.That(new YearQuarter(2021, 1).CompareTo(null), Is.EqualTo(1));
+
+    [Test]
+    public void CompareTo_ItSelf_Compared()
+        => Assert.That(new YearQuarter(2021, 1).CompareTo(new YearQuarter(2021, 1)), Is.EqualTo(0));
+
+    [Test]
+    public void CompareTo_SomethingElse_Compared()
+        => Assert.That(new YearQuarter(2021, 1).CompareTo(new YearQuarter(2022, 3)), Is.EqualTo(-1));
+}

--- a/src/Chrononuensis.Core/Chrononuensis.csproj
+++ b/src/Chrononuensis.Core/Chrononuensis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Chrononuensis.Core/Formats/Lexer.cs
+++ b/src/Chrononuensis.Core/Formats/Lexer.cs
@@ -12,7 +12,7 @@ internal class Lexer
 
     public Format Tokenize(string input)
     {
-        var symbolChars = new[] { 'y', 'M' };
+        var symbolChars = new[] { 'y', 'M', 'q' };
 
         if (string.IsNullOrWhiteSpace(input))
             throw new ArgumentException("Input cannot be null or empty.", nameof(input));
@@ -46,7 +46,6 @@ internal class Lexer
             }
             else if (symbolChars.Contains(currentChar))
             {
-                
                 while (i < inputSpan.Length && inputSpan[i] == currentChar)
                 {
                     token[j++] = currentChar;

--- a/src/Chrononuensis.Core/Formats/Tokens/IQuarterToken.cs
+++ b/src/Chrononuensis.Core/Formats/Tokens/IQuarterToken.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Chrononuensis.Formats.Tokens;
+internal interface IQuarterToken : IPeriodToken
+{ }

--- a/src/Chrononuensis.Core/Formats/Tokens/Quarter/DigitQuarterToken.cs
+++ b/src/Chrononuensis.Core/Formats/Tokens/Quarter/DigitQuarterToken.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chrononuensis.Formats.Tokens.Month;
+
+namespace Chrononuensis.Formats.Tokens.Quarter;
+internal class DigitQuarterToken : FormatToken<DigitQuarterToken>, IQuarterToken
+{ }

--- a/src/Chrononuensis.Core/Formats/Tokens/TokenMapper.cs
+++ b/src/Chrononuensis.Core/Formats/Tokens/TokenMapper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Chrononuensis.Formats.Tokens.Month;
+using Chrononuensis.Formats.Tokens.Quarter;
 using Chrononuensis.Formats.Tokens.Year;
 
 namespace Chrononuensis.Formats.Tokens;
@@ -19,6 +20,8 @@ internal class TokenMapper
         _tokenMap.Add("MM", PaddedDigitMonthToken.Instance);
         _tokenMap.Add("MMM", AbbreviationMonthToken.Instance);
         _tokenMap.Add("MMMM", LabelMonthToken.Instance);
+
+        _tokenMap.Add("q", DigitQuarterToken.Instance);
     }
 
     public FormatToken GetToken(string token)

--- a/src/Chrononuensis.Core/Parsers/Internals/Primitives.cs
+++ b/src/Chrononuensis.Core/Parsers/Internals/Primitives.cs
@@ -11,6 +11,10 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 namespace Chrononuensis.Parsers.Internals;
 internal class Primitives
 {
+    public static Parser<char, int> OneDigitParser(int min, int max) =>
+        Parser.Digit.Repeat(1).Select(chars => int.Parse(new string(chars.ToArray())))
+            .Assert(value => value >= min && value <= max, $"Value must be between {min} and {max}");
+
     public static Parser<char, int> OneOrTwoDigitParser(int min, int max) =>
         Parser.Digit.Then(Parser.Try(Parser.Digit).Optional(),
         (first, second) => int.Parse(second.HasValue

--- a/src/Chrononuensis.Core/Parsers/Internals/QuarterParser.cs
+++ b/src/Chrononuensis.Core/Parsers/Internals/QuarterParser.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Pidgin;
+
+namespace Chrononuensis.Parsers.Internals;
+internal class QuarterParser
+{
+    public static Parser<char, int> OneDigit { get; } = Primitives.OneDigitParser(1,4);
+}
+

--- a/src/Chrononuensis.Core/Parsers/ParserFactory.cs
+++ b/src/Chrononuensis.Core/Parsers/ParserFactory.cs
@@ -20,6 +20,8 @@ internal class ParserFactory
         AddMapping(Tokens.Month.LabelMonthToken.Instance, MonthParser.Label.Cast<object>());
         AddMapping(Tokens.Month.DigitMonthToken.Instance, MonthParser.Digit.Cast<object>());
         AddMapping(Tokens.Month.PaddedDigitMonthToken.Instance, MonthParser.PaddedDigit.Cast<object>());
+
+        AddMapping(Tokens.Quarter.DigitQuarterToken.Instance, QuarterParser.OneDigit.Cast<object>());
                   
         AddMapping(Tokens.Year.DigitOn2YearToken.Instance, YearParser.TwoDigit.Cast<object>());
         AddMapping(Tokens.Year.DigitOn4YearToken.Instance, YearParser.FourDigit.Cast<object>());

--- a/src/Chrononuensis.Core/Parsers/YearQuarterParser.cs
+++ b/src/Chrononuensis.Core/Parsers/YearQuarterParser.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chrononuensis.Formats;
+using Chrononuensis.Formats.Tokens;
+using Chrononuensis.Parsers.Internals;
+using Pidgin;
+
+namespace Chrononuensis.Parsers;
+internal class YearQuarterParser : IParser
+{
+    public static string DefaultPattern { get; } = "yyyy-Qq";
+
+    public (int Year, int Quarter) Parse(string input, string format, IFormatProvider? provider)
+    {
+        var tokens = new Lexer().Tokenize(format);
+
+        var factory = new ParserFactory();
+        var parsers = tokens.Select(factory.Create).ToArray();
+
+        var parser = Primitives.CombineParsers(parsers);
+        var result = parser.Parse(input);
+
+        if (result.Success == false && result.Error is not null)
+        {
+            var ex = new FormatExceptionFactory().Create(result);
+            throw ex;
+        }
+
+        var year = (int)result.Value[tokens.GetIndex<IYearToken>()];
+        var quarter = (int)result.Value[tokens.GetIndex<IQuarterToken>()];
+        return (year, quarter);
+    }
+}

--- a/src/Chrononuensis.Core/YearQuarter.cs
+++ b/src/Chrononuensis.Core/YearQuarter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Chrononuensis.Parsers;
+
+namespace Chrononuensis;
+public record struct YearQuarter(int Year, int Quarter)
+
+    : IParsable<YearQuarter>, IComparable<YearQuarter>, IComparable, IEquatable<YearQuarter>
+{
+    private static YearQuarterParser Parser { get; } = new();
+
+    public static YearQuarter Parse(string input, IFormatProvider? provider)
+        => Parse(input, YearMonthParser.DefaultPattern, provider);
+
+    public static YearQuarter Parse(string input, string format, IFormatProvider? provider = null)
+    {
+        var result = Parser.Parse(input, format, provider);
+        return new YearQuarter(result.Year, result.Quarter);
+    }
+
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out YearQuarter result)
+        => throw new NotImplementedException();
+
+    public readonly int CompareTo(YearQuarter other)
+        => Year == other.Year ? Quarter.CompareTo(other.Quarter) : Year.CompareTo(other.Year);
+
+    public int CompareTo(object? obj)
+        => obj switch
+        {
+            null => 1,
+            YearQuarter ym => CompareTo(ym),
+            _ => throw new ArgumentException("Object must be of type YearQuarter", nameof(obj))
+        };
+
+    public static bool operator < (YearQuarter left, YearQuarter right)
+        => left.CompareTo(right) < 0;
+
+    public static bool operator >(YearQuarter left, YearQuarter right)
+        => left.CompareTo(right) > 0;
+
+    public static bool operator <=(YearQuarter left, YearQuarter right)
+        => left.CompareTo(right) <= 0;
+
+    public static bool operator >=(YearQuarter left, YearQuarter right)
+        => left.CompareTo(right) >= 0;
+}


### PR DESCRIPTION
### Internal Lexers & Parsers:

- Added dedicated lexer and parser for quarter formats:
- q: Parses one-digit quarter.

### Public Parser for YearQuarter:

Introduced a public parser specifically for year-quarter structure, returning the year and quarter as integers.

### New Public Structure: YearQuarter:

- Added a YearQuarter structure with the following features:
- Parse method: Parses input strings into a YearQuarter instance.
- Constructor: Creates a YearQuarter instance from year and month values.
- Comparison operators: Supports equality and comparison for sorting or validation.
  