### PR TITLE
chore: bump NUnit.Analyzers from 4.7.0 to 4.8.0

### DIFF
--- a/src/Chrononuensis.Core.Testing/Chrononuensis.Testing.csproj
+++ b/src/Chrononuensis.Core.Testing/Chrononuensis.Testing.csproj
@@ -3,7 +3,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Chrononuensis.SourceGenerator.Testing/Chrononuensis.SourceGenerator.Testing.csproj
+++ b/src/Chrononuensis.SourceGenerator.Testing/Chrononuensis.SourceGenerator.Testing.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the NUnit.Analyzers package to version 4.8.0 in testing projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->